### PR TITLE
Improve Detection: replace punctuations with whitespace

### DIFF
--- a/lexilang/detector.py
+++ b/lexilang/detector.py
@@ -3,6 +3,7 @@ import os
 from .languages import get_language_weight, is_cjk
 
 _words = None
+_translate_table = str.maketrans(dict.fromkeys("!\"#$%&()*+,/:;<=>?@[\\]^_`{|}~", " "))  # not included . ' -
 
 def detect(text, languages=[]):
     global _words
@@ -18,6 +19,7 @@ def detect(text, languages=[]):
             _words = pickle.load(f, encoding="utf-8")
     
     text = text.lower().strip()
+    text = text.translate(_translate_table)
     if is_cjk(text):
         tokens = list(text)
     else:

--- a/test.py
+++ b/test.py
@@ -1,7 +1,9 @@
 from lexilang.detector import detect
 
-print(detect("bonjour")) # ('fr', 0.45)
+print(detect("bonjour"))   # ('fr', 0.45)
+print(detect("bonjour!"))  # ('fr', 0.45)
 print(detect("学中文")) # ('zh', 0.45)
 print(detect("ciao mondo")) # ('it', 0.9)
 print(detect("El gato doméstico")) # ('es', 0.45)
+print(detect("El\"gato\",doméstico")) # ('es', 0.45)
 print(detect("ciao", languages=["de", "ro"])) # ('de', 0.45)


### PR DESCRIPTION
Improve detection by replacing punctuation with withespace before the tokenization.

`'`, `-` and `.` aren't replaced.

`.`  is used for abbreviations in the Hungarian and Bulgarian dictionaries.
 I think we should also replace it.

We could create a new dictionary for each language to check if a word is an abbreviation before replacing it?

